### PR TITLE
Fix postfix config preseed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,9 +19,7 @@
     - postfix
 
 - name: Pre-seed Postfix configuration
-  command: >
-    /usr/bin/debconf-set-selections /tmp/postfix_selections
-    executable=/bin/bash
+  shell: "/usr/bin/debconf-set-selections /tmp/postfix_selections"
   when: preseed_template|changed
   tags:
     - common


### PR DESCRIPTION
This was causing errors running deb-set-selections saying "cannot find
postfix". Change now uses the shell module.